### PR TITLE
Removes flexibility in laravel version in composer

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,12 @@
 # Laravel Health Check
 
+## Version Compatibility
+
+ Releases | Laravel
+:---------|:--------
+ 1.x      | ^5.7
+ 2.x      | ^7.15
+
 ## Install
 
     composer require arquivei/laravel-health-checker

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   ],
   "require": {
     "php": "^7.3",
-    "laravel/framework": "^5.7 || ^7.15"
+    "laravel/framework": "^5.7"
   },
   "require-dev": {
     "predis/predis": "^1.0",


### PR DESCRIPTION
The possibility of being Laravel 7.* has been removed, because will be separated into two branches and leave a specific one for Laravel 5 (`1.x`).