### PR TITLE
issue-16/make-coverage

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -2,4 +2,8 @@ ARG PHPVERSION="7.3"
 
 FROM arquivei/php:${PHPVERSION}-cli-debian
 WORKDIR /application
-RUN php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer
+RUN php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug
+
+COPY php-ini-overrides.ini  /usr/local/etc/php/conf.d/overrides.ini

--- a/.docker/php-ini-overrides.ini
+++ b/.docker/php-ini-overrides.ini
@@ -1,0 +1,1 @@
+xdebug.mode=coverage

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,7 @@ vendor:
 .PHONY: tests
 tests:
 	$(PHP) vendor/bin/phpunit
+
+.PHONY: coverage
+coverage:
+	$(PHP) vendor/bin/phpunit --coverage-html cover


### PR DESCRIPTION
Creates the `make coverage` command. Also installs `xdebug` dependecy and sets `xdebug.mode=coverage` on `php.ini`

Resolves #16 