### PR TITLE
New alternative to /ready endpoint

### DIFF
--- a/src/Commands/ReadyCheckCommand.php
+++ b/src/Commands/ReadyCheckCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Health\Commands;
+
+use Illuminate\Console\Command;
+use Laravel\Health\Handler\CommandHandler;
+
+class ReadyCheckCommand extends Command
+{
+    protected $signature = 'application:ready-check';
+    protected $description = 'Command to check application readiness';
+
+    public function handle(): void
+    {
+        CommandHandler::handle();
+    }
+}


### PR DESCRIPTION
For worker applications the `/ready` endpoint cannot be used, so we need an alternative.

To solve the problem, I created a command with same behavior as the endpoint.